### PR TITLE
Serve chat app from /chat path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 FROM node:20-alpine AS build
-WORKDIR /app
+WORKDIR /chat
 COPY package*.json ./
 RUN npm install
 COPY . .
@@ -8,7 +8,7 @@ RUN npm run build
 
 # Production stage
 FROM node:20-alpine
-WORKDIR /app
-COPY --from=build /app /app
+WORKDIR /chat
+COPY --from=build /chat /chat
 EXPOSE 8088
 CMD ["npm", "run", "preview", "--", "--host", "0.0.0.0", "--port", "8086"]

--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ This repository contains a React-based chat application built with Vite.
 ```
 
 The container exposes the application on `127.0.0.1:8086` and is started in daemon mode with an automatic restart policy.
+The Dockerfile sets `/chat` as the working directory so the application is served from the `/chat` context instead of the filesystem root.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/chat/',
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
## Summary
- Dockerfile now uses `/chat` as working directory
- update Vite config to build app for `/chat` base path
- document `/chat` working directory in README

## Testing
- `npm install`
- `npm run lint` *(fails: @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68529bc5e7348325b7a8eebbb1cc5345