### PR TITLE
Fix base path support for reverse proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
+ARG BASE_PATH=/
+ENV BASE_PATH=$BASE_PATH
 RUN npm run build
 
 # Production stage

--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
 # hackathon-chat
 
 This repository contains a React-based chat application built with Vite.
+When the application is served behind a reverse proxy under a specific path
+(for example `/chat`), Vite needs to know that base path so that asset URLs are
+generated correctly. Set the `BASE_PATH` environment variable before building
+or running the Docker container to inform Vite of this path. For example:
+
+```bash
+export BASE_PATH=/chat/
+```
 
 ## Running with Docker
 
 1. Ensure [Docker](https://www.docker.com/) is installed on your system.
-2. Execute the provided script to build the image and run the container:
+2. Execute the provided script to build the image and run the container. If the
+   application needs to be served under a sub-path (such as `/chat`), export the
+   desired value in `BASE_PATH` before running the script:
 
 ```bash
 ./run_docker.sh

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -3,5 +3,13 @@ set -e
 
 IMAGE_NAME="hackathon-chat-app"
 
-docker build -t "$IMAGE_NAME" .
+# Forward BASE_PATH to the build so Vite can generate assets with the correct
+# prefix when the application is served behind a reverse proxy.
+if [ -n "$BASE_PATH" ]; then
+  BUILD_ARGS=(--build-arg BASE_PATH="$BASE_PATH")
+else
+  BUILD_ARGS=()
+fi
+
+docker build "${BUILD_ARGS[@]}" -t "$IMAGE_NAME" .
 docker run -d --restart always -p 127.0.0.1:8086:8086 "$IMAGE_NAME"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,11 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  // When the app is served from a sub-path (e.g. behind a reverse proxy),
+  // Vite needs to know the base path so that it can prefix asset URLs
+  // correctly. The base path can be configured through the BASE_PATH
+  // environment variable. When not provided, it falls back to '/'.
+  base: process.env.BASE_PATH || '/',
   plugins: [react()],
   optimizeDeps: {
     exclude: ['lucide-react'],


### PR DESCRIPTION
## Summary
- allow configuring base path via `BASE_PATH` environment variable
- document how to build with a base path
- pass `BASE_PATH` to the docker build
- build Docker image with `BASE_PATH` for Vite

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852a1cce8c08325be73a057dfc6f937