### PR TITLE
Fix default BASE_PATH for reverse proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
-ARG BASE_PATH=/
+ARG BASE_PATH=/chat/
 ENV BASE_PATH=$BASE_PATH
 RUN npm run build
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 This repository contains a React-based chat application built with Vite.
 When the application is served behind a reverse proxy under a specific path
 (for example `/chat`), Vite needs to know that base path so that asset URLs are
-generated correctly. Set the `BASE_PATH` environment variable before building
-or running the Docker container to inform Vite of this path. For example:
+generated correctly. The provided Docker helper script automatically sets the
+base path to `/chat/` if none is supplied via the `BASE_PATH` environment
+variable. To override the default, export a different value before running the
+script. For example:
 
 ```bash
 export BASE_PATH=/chat/
@@ -13,9 +15,9 @@ export BASE_PATH=/chat/
 ## Running with Docker
 
 1. Ensure [Docker](https://www.docker.com/) is installed on your system.
-2. Execute the provided script to build the image and run the container. If the
-   application needs to be served under a sub-path (such as `/chat`), export the
-   desired value in `BASE_PATH` before running the script:
+2. Execute the provided script to build the image and run the container. The
+   application will be built with the `/chat/` base path unless you override it
+   via `BASE_PATH`:
 
 ```bash
 ./run_docker.sh

--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hackathon Chat</title>
   </head>

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -4,12 +4,13 @@ set -e
 IMAGE_NAME="hackathon-chat-app"
 
 # Forward BASE_PATH to the build so Vite can generate assets with the correct
-# prefix when the application is served behind a reverse proxy.
-if [ -n "$BASE_PATH" ]; then
-  BUILD_ARGS=(--build-arg BASE_PATH="$BASE_PATH")
-else
-  BUILD_ARGS=()
+# prefix when the application is served behind a reverse proxy.  If the user
+# doesn't provide one, default to "/chat/" so that the container works out of
+# the box when proxied under that path.
+if [ -z "$BASE_PATH" ]; then
+  BASE_PATH="/chat/"
 fi
+BUILD_ARGS=(--build-arg BASE_PATH="$BASE_PATH")
 
 docker build "${BUILD_ARGS[@]}" -t "$IMAGE_NAME" .
 docker run -d --restart always -p 127.0.0.1:8086:8086 "$IMAGE_NAME"


### PR DESCRIPTION
## Summary
- default Docker builds to `/chat/` base path so assets work behind a reverse proxy
- document the default and make the run script set `BASE_PATH` automatically
- remove unused Vite favicon reference

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852a5cd74ec83259d0cd90dce1ec672