### PR TITLE
Fix styled-jsx warnings

### DIFF
--- a/src/components/UI/Button.tsx
+++ b/src/components/UI/Button.tsx
@@ -80,7 +80,7 @@ export function Button({
         </>
       )}
       
-      <style jsx>{`
+      <style>{`
         .expand-on-hover:hover .button-text {
           max-width: 8rem;
           opacity: 1;

--- a/src/components/UI/Slider.tsx
+++ b/src/components/UI/Slider.tsx
@@ -72,7 +72,7 @@ export function Slider({
         </p>
       )}
       
-      <style jsx>{`
+      <style>{`
         .slider-thumb::-webkit-slider-thumb {
           appearance: none;
           width: 24px;


### PR DESCRIPTION
## Summary
- remove stray `jsx` attribute from style tags in Button and Slider components

## Testing
- `npm run lint` *(fails: some unrelated lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852ed631c8083258e5adae0e8bcc8e4