### PR TITLE
Refactor advanced reasoning evaluation

### DIFF
--- a/src/services/strategy/advancedReasoning.ts
+++ b/src/services/strategy/advancedReasoning.ts
@@ -1,4 +1,3 @@
-import { HistoryMessageType } from '../../schema';
 import { OllamaService } from '../ollama';
 import { StrategyTaskManager } from './strategyTaskManager';
 
@@ -6,29 +5,12 @@ interface ReasoningIndicators {
   complexityScore: number;
   frustrationScore: number;
   repetitionScore: number;
-  longConversationBonus: number;
-  backAndForthBonus: number;
   totalScore: number;
 }
 
 // Calculate reasoning indicators based on conversation analysis
-function calculateReasoningIndicators(history: HistoryMessageType[], userIntent: string): ReasoningIndicators {
-  // Extract all conversation content for analysis
-  const conversationContent = history
-    .map(msg => {
-      if (msg.content.type === 'formatted') {
-        return msg.content.blocks
-          .map(block => block.type === 'markdown' ? block.text : block.code)
-          .join(' ');
-      } else if (msg.content.type === 'toolCall') {
-        return msg.content.display;
-      }
-      return '';
-    })
-    .join(' ')
-    .toLowerCase();
-
-  const fullContext = `${conversationContent} ${userIntent}`.toLowerCase();
+function calculateReasoningIndicators(userIntent: string): ReasoningIndicators {
+  const fullContext = userIntent.toLowerCase();
   
   // Keywords indicating complex reasoning needs
   const complexityKeywords = [
@@ -90,35 +72,24 @@ function calculateReasoningIndicators(history: HistoryMessageType[], userIntent:
     repetitionScore += matches * 1.5; // Repetition is a moderate indicator
   });
 
-  // Check conversation length - longer conversations might benefit from thinking
-  const conversationLength = history.length;
-  const longConversationBonus = conversationLength > 10 ? 1 : 0;
-
-  // Check for back-and-forth patterns (potential confusion)
-  const userMessages = history.filter(msg => msg.actor === 'user');
-  const backAndForthBonus = userMessages.length > 3 ? 1 : 0;
-
-  const totalScore = complexityScore + frustrationScore + repetitionScore + longConversationBonus + backAndForthBonus;
+  const totalScore = complexityScore + frustrationScore + repetitionScore;
 
   return {
     complexityScore,
     frustrationScore,
     repetitionScore,
-    longConversationBonus,
-    backAndForthBonus,
     totalScore
   };
 }
 
 // Use LLM to make the final decision about advanced reasoning
 async function decideAdvancedReasoningWithLLM(
-  history: HistoryMessageType[],
   userIntent: string,
   indicators: ReasoningIndicators,
   taskManager: StrategyTaskManager
 ): Promise<boolean> {
   try {
-    taskManager.updateTaskMessage('advanced-reasoning', 'Consultation du modèle pour la décision...');
+  taskManager.updateTaskMessage('advanced-reasoning', 'Consultation du modèle pour la décision...');
 
     // Build system prompt for the reasoning evaluator
     const systemPrompt = `You are a reasoning evaluator. Your job is to determine whether a complex AI reasoning mode (thinking mode) should be activated for a user's query.
@@ -129,14 +100,11 @@ DECISION CRITERIA:
 
 ANALYSIS CONTEXT:
 You have access to conversation indicators that have been pre-analyzed:
-- Complexity score: ${indicators.complexityScore} (keywords indicating complex reasoning needs)
-- Frustration score: ${indicators.frustrationScore} (user showing frustration or difficulty)
-- Repetition score: ${indicators.repetitionScore} (user asking for clarification or repetition)
-- Long conversation bonus: ${indicators.longConversationBonus} (extended back-and-forth)
-- Back-and-forth bonus: ${indicators.backAndForthBonus} (multiple user interactions)
-- Total preliminary score: ${indicators.totalScore}
+  - Complexity score: ${indicators.complexityScore} (keywords indicating complex reasoning needs)
+  - Frustration score: ${indicators.frustrationScore} (user showing frustration or difficulty)
+  - Repetition score: ${indicators.repetitionScore} (user asking for clarification or repetition)
+  - Total preliminary score: ${indicators.totalScore}
 
-CONVERSATION LENGTH: ${history.length} messages
 USER INTENT: "${userIntent}"
 
 RESPONSE FORMAT:
@@ -148,25 +116,11 @@ You MUST respond with valid JSON in this exact format:
 
 Consider the conversation context, user intent, and indicators to make your decision.`;
 
-    // Build user prompt with conversation summary
-    const recentMessages = history.slice(-6); // Last 6 messages for context
-    const conversationSummary = recentMessages.map((msg, index) => {
-      const content = msg.content.type === 'formatted' 
-        ? msg.content.blocks.map(block => block.type === 'markdown' ? block.text : block.code).join(' ')
-        : msg.content.display;
-      
-      return `${msg.actor.toUpperCase()}: ${content.substring(0, 200)}${content.length > 200 ? '...' : ''}`;
-    }).join('\n');
-
-    const userPrompt = `CONVERSATION CONTEXT (recent messages):
-${conversationSummary}
-
-EXTRACTED USER INTENT: "${userIntent}"
+  const userPrompt = `EXTRACTED USER INTENT: "${userIntent}"
 
 ANALYSIS SUMMARY:
-- Total complexity indicators: ${indicators.totalScore}
-- Primary factors: ${indicators.complexityScore > 0 ? `complexity (${indicators.complexityScore})` : ''} ${indicators.frustrationScore > 0 ? `frustration (${indicators.frustrationScore})` : ''} ${indicators.repetitionScore > 0 ? `repetition (${indicators.repetitionScore})` : ''}
-- Conversation factors: ${indicators.longConversationBonus > 0 ? 'long conversation' : ''} ${indicators.backAndForthBonus > 0 ? 'multiple exchanges' : ''}
+  - Total complexity indicators: ${indicators.totalScore}
+  - Primary factors: ${indicators.complexityScore > 0 ? `complexity (${indicators.complexityScore})` : ''} ${indicators.frustrationScore > 0 ? `frustration (${indicators.frustrationScore})` : ''} ${indicators.repetitionScore > 0 ? `repetition (${indicators.repetitionScore})` : ''}
 
 Should thinking mode be activated for this user query?`;
 
@@ -215,12 +169,9 @@ Should thinking mode be activated for this user query?`;
     console.log(`      - Complexity: ${indicators.complexityScore}`);
     console.log(`      - Frustration: ${indicators.frustrationScore}`);
     console.log(`      - Repetition: ${indicators.repetitionScore}`);
-    console.log(`      - Long conversation: ${indicators.longConversationBonus}`);
-    console.log(`      - Back-and-forth: ${indicators.backAndForthBonus}`);
     console.log(`      - Total Score: ${indicators.totalScore}`);
     console.log(`   🧠 LLM Decision: ${decision.activate_thinking_mode ? 'ACTIVATE' : 'SKIP'} thinking mode`);
     console.log(`   💬 LLM Reason: "${decision.reason}"`);
-    console.log(`   📝 Conversation Length: ${history.length} messages`);
 
     return decision.activate_thinking_mode;
 
@@ -241,7 +192,6 @@ Should thinking mode be activated for this user query?`;
 
 // Main function: Advanced reasoning decision with LLM consultation
 export async function shouldActivateAdvancedReasoning(
-  history: HistoryMessageType[],
   userIntent: string,
   taskManager: StrategyTaskManager
 ): Promise<boolean> {
@@ -249,7 +199,7 @@ export async function shouldActivateAdvancedReasoning(
     taskManager.updateTaskMessage('advanced-reasoning', 'Analyse des indicateurs de complexité...');
 
     // Step 1: Calculate reasoning indicators
-    const indicators = calculateReasoningIndicators(history, userIntent);
+    const indicators = calculateReasoningIndicators(userIntent);
     
     // Step 2: Check preliminary threshold
     if (indicators.totalScore < 3) {
@@ -267,7 +217,6 @@ export async function shouldActivateAdvancedReasoning(
     taskManager.updateTaskMessage('advanced-reasoning', 'Seuil atteint, consultation du modèle...');
     
     const llmDecision = await decideAdvancedReasoningWithLLM(
-      history,
       userIntent,
       indicators,
       taskManager
@@ -278,8 +227,6 @@ export async function shouldActivateAdvancedReasoning(
     if (indicators.complexityScore > 0) reasoningDetails.push(`complexité: ${indicators.complexityScore}`);
     if (indicators.frustrationScore > 0) reasoningDetails.push(`frustration: ${indicators.frustrationScore}`);
     if (indicators.repetitionScore > 0) reasoningDetails.push(`répétition: ${indicators.repetitionScore}`);
-    if (indicators.longConversationBonus > 0) reasoningDetails.push('conversation longue');
-    if (indicators.backAndForthBonus > 0) reasoningDetails.push('échanges multiples');
 
     if (llmDecision) {
       taskManager.completeTask('advanced-reasoning', `Activé par LLM (score: ${indicators.totalScore} - ${reasoningDetails.join(', ')})`);

--- a/src/services/strategy/mainStrategy.ts
+++ b/src/services/strategy/mainStrategy.ts
@@ -112,7 +112,6 @@ export async function runStrategy(
     taskManager.startTask('advanced-reasoning', 'Évaluation du besoin de réflexion avancée...');
     
     const activateThinkMode = await shouldActivateAdvancedReasoning(
-      history,
       extractedUserIntent,
       taskManager
     );


### PR DESCRIPTION
## Summary
- simplify reasoning indicators
- remove conversation history checks
- base advanced reasoning activation solely on latest user intent

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852fb6848d88325ad7df68ca1ddec1f